### PR TITLE
Smets2 units

### DIFF
--- a/example-octograph.ini
+++ b/example-octograph.ini
@@ -25,3 +25,9 @@ mpan = 12345
 serial_number = 12A3456
 standing_charge = 16.80
 unit_rate = 3.03
+# 1 for SMETS1 meters, 2 for SMETS2 meters
+meter_type = 1
+# volume correction factor, and calorific values used to convert SMETS2 consumption from m^3 to kWh
+# Defaults are typically used values. Your energy bill will show you the values used for your supply.
+volume_correction_factor = 1.02264
+calorific_value = 40


### PR DESCRIPTION
SMETS2 gas meter consumption is measured in m3 rather than kWh, so conversion
from one unit to the other is required.
Algorithm and description of terms is taken from:
https://www.theenergyshop.com/guides/how-to-convert-gas-units-to-kwh

This commit adds additional config file options to the `gas` section:
- `meter_type` (default `1` for backward compatibility)
  Enables unit conversion from m3 to kWh before reporting metrics to influxdb
- `volume_correction_factor` (default `1.02264`)
- `calorific_value` (default `40`)

Fixes #8 (hopefully)